### PR TITLE
CF manifest gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "serde_json",
+ "serde_jsonrc",
  "sha1",
  "termion",
  "tokio",
@@ -1025,6 +1025,16 @@ name = "serde_json"
 version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_jsonrc"
+version = "0.1.2"
+source = "git+https://github.com/qwertz19281/serde-jsonrc?rev=131ffb5f#131ffb5f54df275bf013fc33984296d35b89951a"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 [dependencies]
 serde = "1"
 serde_derive = "1"
-serde_json = "1"
+serde_jsonrc = { git = "https://github.com/qwertz19281/serde-jsonrc", rev = "131ffb5f" }
 clap = { version = "4", features = ["derive"] }
 ureq = { version = "2", features = ["json"] }
 anyhow = "1"
@@ -28,7 +28,7 @@ rustc-hash = "1.1"
 regex = "1.4"
 furse = { git = "https://github.com/CursedOnes/furse", rev = "b18b02ef" }
 futures = "0.3"
-reqwest = { version = "~0.11.12", default-features = false, features = [
+reqwest = { version = "0.11.12", default-features = false, features = [
     "json",
     "rustls-tls",
 ] } # TODO ability to use reqwest error codes in furse without also importing it as dependency

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ State: WIP, all features mentioned in the README do work. Few side functions and
 ```console
 # Build with API keys
 CURSEFORGE_API_KEY='...' cargo install -f --git https://github.com/CursedOnes/cursinator
-# Build without API keys, the API keys must be supplied at runtime, via CURSEFORGE_API_KEY or inside repo.conf
+# Build without API keys, the API keys must then be supplied at runtime, via CURSEFORGE_API_KEY or inside repo.conf
 CURSEFORGE_API_KEY= cargo install -f --git https://github.com/CursedOnes/cursinator
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ State: WIP, all features mentioned in the README do work. Few side functions and
 - Update addon or all addons  
 - Remove/Purge addon  
 - Create .url.txt for downloaded files  
+- Generate CurseForge modpack manifest.json from template  
 
 # Install
 

--- a/cf_manifest_template_example.jsonc
+++ b/cf_manifest_template_example.jsonc
@@ -1,0 +1,30 @@
+{
+  "manifestVersion": 1,
+  "files": [
+    {
+      "cursinator_slug": "foamfix-optimization-mod", // Entry for addon by slug
+      "required": false
+      // cursinator will fill the fileID and other addon properties
+    },
+    {
+      "projectID": "12345",
+      "cursinator_exclude": true // Exclude this addon, the entire entry won't be in the generated manifest
+    },
+    {
+      "cursinator_slug": "debug-addon",
+      "cursinator_exclude": true // Exclude this addon, the entire entry won't be in the generated manifest
+    },
+    {
+      "cursinator_ignore": true, // cursinator won't touch this entry and keep it as-is (the "cursinator_*" fields won't be in the generated manifest)
+      "projectID": "32274",
+      "fileID": "4012858",
+      "required": true
+    },
+    {
+      "projectID": "220311" // Entry for addon by projectID
+      // cursinator will fill the fileID and other addon properties
+    },
+    // cursinator will fill in the remaining installed addons which weren't already specified or excluded above
+  ]
+}
+// see cf_manifest_template_example_result.json for a resulting manifest.json example

--- a/cf_manifest_template_example_result.json
+++ b/cf_manifest_template_example_result.json
@@ -1,0 +1,25 @@
+{
+  "manifestVersion": 1,
+  "files": [
+    {
+      "projectID": "278494",
+      "fileID": "3973967",
+      "required": false
+    },
+    {
+      "projectID": "32274",
+      "fileID": "4012858",
+      "required": true
+    },
+    {
+      "projectID": "220311",
+      "fileID": "3169926",
+      "required": true
+    },
+    {
+      "projectID": "345678",
+      "fileID": "234567",
+      "required": true
+    }
+  ]
+}

--- a/src/cmd/fill_cf_manifest.rs
+++ b/src/cmd/fill_cf_manifest.rs
@@ -14,13 +14,13 @@ pub fn main(
 ) -> bool {
     let mut manifest: CfManifest = {
         let template_json = unwrap_result_error!(std::fs::read(input), |e|"Failed to read template: {}",e);
-        unwrap_result_error!(serde_json::from_slice(&template_json), |e|"Failed to decode template: {}",e)
+        unwrap_result_error!(serde_jsonrc::from_slice(&template_json), |e|"Failed to decode template: {}",e)
     };
 
     process(&mut manifest, repo);
 
     let mut buf = Vec::with_capacity(1024*1024);
-    unwrap_result_error!(serde_json::to_writer_pretty(&mut buf, &manifest), |e|"Failed to encode manifest: {}",e);
+    unwrap_result_error!(serde_jsonrc::to_writer_pretty(&mut buf, &manifest), |e|"Failed to encode manifest: {}",e);
     unwrap_result_error!(std::fs::write(output,&buf), |e|"Failed to write manifest: {}",e);
     
     false
@@ -50,10 +50,10 @@ fn process(manifest: &mut CfManifest, repo: &Repo) {
 pub struct CfManifest {
     #[serde(rename = "manifestVersion")]
     #[serde(default)]
-    manifest_version: serde_json::Value,
+    manifest_version: serde_jsonrc::Value,
 
     #[serde(flatten)]
-    other: serde_json::Value,
+    other: serde_jsonrc::Value,
 
     files: Vec<CfMFile>,
 }
@@ -83,7 +83,7 @@ pub struct CfMFile {
     required: Option<bool>,
 
     #[serde(flatten)]
-    other: serde_json::Value,
+    other: serde_jsonrc::Value,
 }
 
 impl CfMFile {
@@ -143,7 +143,7 @@ impl CfMFile {
             project_id: Some(addon.id.0),
             file_id: Some(addon.installed.as_ref().unwrap().id.0),
             required: Some(true),
-            other: serde_json::Value::Object(serde_json::Map::new()),
+            other: serde_jsonrc::Value::Object(serde_jsonrc::Map::new()),
         }
     }
 }

--- a/src/cmd/fill_cf_manifest.rs
+++ b/src/cmd/fill_cf_manifest.rs
@@ -1,0 +1,141 @@
+use serde::{Deserialize, Serialize};
+
+use crate::addon::local::LocalAddon;
+use crate::conf::Repo;
+use crate::{error, warn};
+
+fn process(manifest: &mut CfManifest, repo: &Repo) {
+    if manifest.manifest_version.as_i64() != Some(1) {
+        warn!("Unknown CfManifest template version ({})",manifest.manifest_version);
+    }
+
+    let mut remaining_addons: Vec<&LocalAddon> = repo.addons.values().collect();
+
+    for entry in &mut manifest.files {
+        entry.handle_entry(&mut remaining_addons);
+    }
+
+    handle_entries_post(&mut manifest.files);
+
+    for addon in remaining_addons {
+        manifest.files.push(CfMFile::auto_create(addon));
+    }
+}
+
+#[derive(Deserialize,Serialize)]
+pub struct CfManifest {
+    #[serde(rename = "manifestVersion")]
+    manifest_version: serde_json::Value,
+
+    files: Vec<CfMFile>,
+
+    #[serde(flatten)]
+    other: serde_json::Value,
+}
+
+#[derive(Deserialize,Serialize)]
+pub struct CfMFile {
+    /// If set, cursinator will ignore this entry with manually filled in data.
+    #[serde(skip_serializing)]
+    #[serde(default)]
+    cursinator_ignore: bool,
+    /// Entries with cursinator_exclude will be removed, unless cursinator_ignore is set.
+    /// 
+    /// Combine with cursinator_slug or project_id to exclude an addon
+    #[serde(skip_serializing)]
+    #[serde(default)]
+    cursinator_exclude: bool,
+    /// If set, try to resolve slug and fill with it instead of projectID
+    #[serde(skip_serializing)]
+    cursinator_slug: Option<String>,
+
+    #[serde(rename = "fileID")]
+    file_id: Option<u64>,
+
+    required: Option<bool>,
+
+    #[serde(rename = "projectID")]
+    project_id: Option<u64>,
+
+    #[serde(flatten)]
+    other: serde_json::Value,
+}
+
+impl CfMFile {
+    fn handle_entry(&mut self, remaining: &mut Vec<&LocalAddon>) {
+        if self.cursinator_ignore {
+            // cursinatore_exclude should also be ignored if cursinator_ignore is set
+            self.cursinator_exclude = false;
+        } else if let Some(slug) = &self.cursinator_slug {
+            // try resolve cursinator_slug and fill project_id and file
+            if let Some(id) = self.project_id {
+                warn!("Both cursinator_slug ({slug}) and projectID ({id}) set. cursinator_slug is prioritized");
+            }
+            if let Some(idx) = find_entry_by_id_or_slug(slug, remaining) {
+                let addon = remaining[idx];
+                remaining.swap_remove(idx);
+
+                self.project_id = Some(addon.id.0);
+
+                if self.required.is_none() {
+                    self.required = Some(true);
+                }
+                if self.file_id.is_none() {
+                    self.file_id = Some(addon.installed.as_ref().unwrap().id.0);
+                }
+            } else {
+                error!("cursinator_slug not found: {slug}");
+            }
+        } else if let Some(id) = self.project_id {
+            // fill in file if only projectID is given
+            if let Some(idx) = find_entry_by_id(id, remaining) {
+                let addon = remaining[idx];
+                remaining.swap_remove(idx);
+
+                if self.required.is_none() {
+                    self.required = Some(true);
+                }
+                if self.file_id.is_none() {
+                    self.file_id = Some(addon.installed.as_ref().unwrap().id.0);
+                }
+            } else {
+                error!("projectID not bound: {id}");
+            }
+        }
+        // whatever happens, we will remove mentioned projectID from remaining, so they won't be autofilled later
+        if let Some(id) = self.project_id {
+            if let Some(idx) = find_entry_by_id(id, remaining) {
+                remaining.swap_remove(idx);
+            }
+        }
+    }
+
+    fn auto_create(addon: &LocalAddon) -> Self {
+        Self {
+            cursinator_ignore: true,
+            cursinator_exclude: false,
+            cursinator_slug: None,
+            file_id: Some(addon.installed.as_ref().unwrap().id.0),
+            required: Some(true),
+            project_id: Some(addon.id.0),
+            other: serde_json::Value::Object(serde_json::Map::new()),
+        }
+    }
+}
+
+fn handle_entries_post(v: &mut Vec<CfMFile>) {
+    v.retain(|v| !v.cursinator_exclude );
+}
+
+fn find_entry_by_id_or_slug(v: &str, list: &[&LocalAddon]) -> Option<usize> {
+    if let Ok(i) = v.parse::<u64>() {
+        if let Some(i) = find_entry_by_id(i, list) {
+            return Some(i);
+        }
+    }
+    list.iter().enumerate().find(|(_,addon)| addon.slug.0.trim() == v.trim() ).map(|(i,_)| i )
+}
+
+fn find_entry_by_id(v: u64, list: &[&LocalAddon]) -> Option<usize> {
+    list.iter().enumerate().find(|(_,addon)| addon.id.0 == v ).map(|(i,_)| i )
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -23,6 +23,7 @@ pub mod disable;
 pub mod enable;
 pub mod search;
 pub mod download_all;
+pub mod fill_cf_manifest;
 
 pub fn main(o: Op) {
     if let OpCmd::Init { game_version, game_version_regex } = o.cmd.clone() {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -88,6 +88,8 @@ pub fn main(o: Op) {
             aset::main(&o,&mut repo,addon,key,value),
         OpCmd::Rset { key, value } => 
             rset::main(&o,&mut repo,key,value),
+        OpCmd::GenCfManifest { input, output } =>
+            fill_cf_manifest::main(&o, &repo, input, output),
     };
 
     if modified {

--- a/src/conf/mod.rs
+++ b/src/conf/mod.rs
@@ -41,24 +41,26 @@ impl Repo {
             Err(e) if e.kind() == ErrorKind::NotFound => return Ok(None),
             Err(e) => return Err(e.into()),
         };
-        match serde_json::from_str(&f) {
+        match serde_jsonrc::from_str(&f) {
             Ok(c) => Ok(Some(c)),
             Err(e) => Err(e.into()),
         }
     }
     pub fn save(&self, conf: impl AsRef<Path>) -> anyhow::Result<()> {
         let conf_part = part_file_path(conf.as_ref());
-        let f = file_write(&conf_part)?; //TODO fix, .part
-        let f = BufWriter::new(f);
-        serde_json::to_writer_pretty(f, self)?;
+
+        let mut buf = Vec::with_capacity(1024*1024);
+        serde_jsonrc::to_writer_pretty(&mut buf, self)?;
+        std::fs::write(&conf_part, buf)?; //TODO fix, .part
+
         remove_if(&conf)?;
         std::fs::rename(conf_part, conf)?;
         Ok(())
     }
     pub fn save_new(&self, conf: impl AsRef<Path>) -> anyhow::Result<()> {
-        let f = file_write_new(conf)?; //TODO fix
-        let f = BufWriter::new(f);
-        serde_json::to_writer_pretty(f, self)?;
+        let mut buf = Vec::with_capacity(1024*1024);
+        serde_jsonrc::to_writer_pretty(&mut buf, self)?;
+        std::fs::write(conf, buf)?;
         Ok(())
     }
     pub fn sort_deps(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,4 +252,14 @@ pub enum OpCmd {
         #[arg()]
         value: Option<String>,
     },
+    /// Generate CF manifest.json from template
+    #[command(name = "gen-cf-manifest")]
+    GenCfManifest {
+        /// Input template
+        #[arg()]
+        input: PathBuf,
+        /// Output manifest.json
+        #[arg()]
+        output: PathBuf,
+    },
 }


### PR DESCRIPTION
Generate manifest.json for CurseForge modpacks from template. The addon data will be filled in, it also allows customizing properties of a addons with e.g.

- `cursinator_slug` to define addon by slug instead of projectID
- `cursinator_exclude: true` to exclude addon (entry)
e.g. `{ "cursinator_slug": "foo", "cursinator_exclude";: true }` to exclude foo
- `cursinator_ignore` to tell cursinator not to touch or fill an entry

and the remaining addons not mentioned in a entry by `projectID` or `cursinator_slug` will also be added.